### PR TITLE
dataset sending: keys->data

### DIFF
--- a/frontend/src/components/DataTable/DataTable.jsx
+++ b/frontend/src/components/DataTable/DataTable.jsx
@@ -545,7 +545,8 @@ export default function DataTable({ config, extra = [] }) {
   const saved = () => {
     setLoading(true);
     const entity = 'dataset';
-    const requestData = [DatasetName, ...selectedRowKeys];
+    // const requestData = [DatasetName, ...selectedRowKeys];
+    const requestData = dataSource.filter(item => selectedRowKeys.includes(item._id));
     console.log('requestData: ', requestData);
 
     dispatch(crud.create({ entity, jsonData: requestData }));


### PR DESCRIPTION
## Description

We were originally sending only the key id of selected data, but now we are sending the entire selected data.

## Screenshots (if applicable)

<img width="799" alt="スクリーンショット 2024-09-04 11 33 53" src="https://github.com/user-attachments/assets/721ba99d-4c17-4d2d-b174-1fbc80fa556d">


## Checklist

- [ ] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the codebase
- [ ] My changes generate no new warnings or errors
- [ ] The title of my pull request is clear and descriptive
